### PR TITLE
feat: migrate metrics/nas and metrics/ngap to new nas/ngap API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.26.2
 
 require (
 	github.com/evanphx/json-patch/v5 v5.9.0
-	github.com/free5gc/nas v1.2.3
-	github.com/free5gc/ngap v1.1.3
+	github.com/free5gc/nas v1.2.4-0.20260707083822-348faf940c55
+	github.com/free5gc/ngap v1.1.4-0.20260707055048-c26215fe47ef
 	github.com/gin-gonic/gin v1.10.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/mitchellh/mapstructure v1.5.0
@@ -21,6 +21,7 @@ require (
 )
 
 require (
+	github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/sonic v1.11.6 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
@@ -28,7 +29,6 @@ require (
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/free5gc/aper v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4aoV2Iu8bR55nU6iKMVfYVLjY=
+github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
@@ -16,12 +18,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
-github.com/free5gc/aper v1.1.1 h1:O1WHg8J/Ab+TtpYuDjdUkoVv1dpR/K7L1/edP9+OujI=
-github.com/free5gc/aper v1.1.1/go.mod h1:erN7J8emgUvCFydYcPhHtknRfeHocPRJuGldpvXLE5I=
-github.com/free5gc/nas v1.2.3 h1:vMA9NGORw0zr26vQWWSTy8X9HrA+wGxFvwc2g9KqUTw=
-github.com/free5gc/nas v1.2.3/go.mod h1:A8ODi6MW0fRJiLEH4GcUPbg3dd9xm3zi+fkBWqTjQ40=
-github.com/free5gc/ngap v1.1.3 h1:uT+IE5PkWOYjPdxCyOAwLDOXUiADcOQCs05CudyC36s=
-github.com/free5gc/ngap v1.1.3/go.mod h1:yGMO2GYV5DbbmudwD7Oo6dXQgz2ON29GhqtXDeXdyvA=
+github.com/free5gc/nas v1.2.4-0.20260707083822-348faf940c55 h1:II2TnEwOTj6z+Iiq+iq5F4puxtaX1fvASytwxyg/68s=
+github.com/free5gc/nas v1.2.4-0.20260707083822-348faf940c55/go.mod h1:T/krdGjxSut+MQJAFFBS4lsWZa/NPEz7wO0G/D3qHeE=
+github.com/free5gc/ngap v1.1.4-0.20260707055048-c26215fe47ef h1:+TrPHbLcROsjDUuwsMBQTAi7SeKMP2o0v7xjsTJEJ8s=
+github.com/free5gc/ngap v1.1.4-0.20260707055048-c26215fe47ef/go.mod h1:1lfw7JP0fs8bdv0B685KDC2/shOciL9gf1f3KwKnGvk=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/metrics/nas/message.go
+++ b/metrics/nas/message.go
@@ -1,13 +1,15 @@
+// Package nas: NAS message metrics, built against the new
+// github.com/free5gc/nas API (ie/message packages).
 package nas
 
 import (
+	"reflect"
 	"regexp"
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/free5gc/nas"
-	"github.com/free5gc/nas/nasMessage"
-	"github.com/free5gc/nas/nasType"
+	nasie "github.com/free5gc/nas/ie"
+	"github.com/free5gc/nas/message"
 	"github.com/free5gc/util/metrics/utils"
 )
 
@@ -52,10 +54,13 @@ func removeDigitSuffix(s string) string {
 	return suffixRe.ReplaceAllString(s, "")
 }
 
-func IncrMetricsRcvNasMsg(msg *nas.Message, isStatusSuccess *bool, cause *string) {
+func IncrMetricsRcvNasMsg(msg message.Message, isStatusSuccess *bool, cause *string) {
 	if IsNasMetricsEnabled() {
 		nasMessageIe := getMessageStrFromGmmMessage(msg)
-		metricCause := removeDigitSuffix(nasMessage.Cause5GMMToString(nasMessageIe.cause.Octet))
+		metricCause := ""
+		if nasMessageIe.cause != nil {
+			metricCause = removeDigitSuffix(nasMessageIe.cause.String())
+		}
 		metricStatus := utils.FailureMetric
 
 		if cause != nil && *cause != "" {
@@ -79,7 +84,8 @@ func IncrMetricsSentNasMsgs(msgType string, isStatusSuccess *bool, cause5GMM uin
 		errCause := ""
 
 		if cause5GMM != 0 {
-			errCause = removeDigitSuffix(nasMessage.Cause5GMMToString(cause5GMM))
+			gmmCause := nasie.Cause5GMM{Value: cause5GMM}
+			errCause = removeDigitSuffix(gmmCause.String())
 		} else if otherCause != nil {
 			errCause = *otherCause
 		}
@@ -98,84 +104,100 @@ func IncrMetricsSentNasMsgs(msgType string, isStatusSuccess *bool, cause5GMM uin
 	}
 }
 
-type IeFromGmmMessage struct {
-	nasMessageType string
-	cause          nasType.Cause5GMM
+// msgTypeToMetricName pins the "name" label of the NAS metrics to the constants
+// in types.go instead of letting it follow message.MsgType.String(), whose
+// values belong to github.com/free5gc/nas and may change without notice here.
+// Every 5GMM message type of that module must have an entry; msgTypeCoverage in
+// message_test.go fails when upstream adds one that is missing below.
+var msgTypeToMetricName = map[message.MsgType]string{
+	message.MsgTypeRegReq:                      REGISTRATION_REQUEST,
+	message.MsgTypeRegAccept:                   REGISTRATION_ACCEPT,
+	message.MsgTypeRegComplete:                 REGISTRATION_COMPLETE,
+	message.MsgTypeRegRej:                      REGISTRATION_REJECT,
+	message.MsgTypeDeregReqUEOrig:              DEREGISTRATION_REQUEST_UE_ORIGINATING_DEREGISTRATION,
+	message.MsgTypeDeregAcceptUEOrig:           DEREGISTRATION_ACCEPT_UE_ORIGINATING_DEREGISTRATION,
+	message.MsgTypeDeregReqUETerm:              DEREGISTRATION_REQUEST_UE_TERMINATED_DEREGISTRATION,
+	message.MsgTypeDeregAcceptUETerm:           DEREGISTRATION_ACCEPT_UE_TERMINATED_DEREGISTRATION,
+	message.MsgTypeSvcReq:                      SERVICE_REQUEST,
+	message.MsgTypeSvcRej:                      SERVICE_REJECT,
+	message.MsgTypeSvcAccept:                   SERVICE_ACCEPT,
+	message.MsgTypeCtrlPlaneSvcReq:             CONTROL_PLANE_SERVICE_REQUEST,
+	message.MsgTypeNwSliceSpecificAuthCmd:      NETWORK_SLICE_SPECIFIC_AUTHENTICATION_COMMAND,
+	message.MsgTypeNwSliceSpecificAuthComplete: NETWORK_SLICE_SPECIFIC_AUTHENTICATION_COMPLETE,
+	message.MsgTypeNwSliceSpecificAuthResult:   NETWORK_SLICE_SPECIFIC_AUTHENTICATION_RESULT,
+	message.MsgTypeCfgUpdateCmd:                CONFIGURATION_UPDATE_COMMAND,
+	message.MsgTypeCfgUpdateComplete:           CONFIGURATION_UPDATE_COMPLETE,
+	message.MsgTypeAuthReq:                     AUTHENTICATION_REQUEST,
+	message.MsgTypeAuthRsp:                     AUTHENTICATION_RESPONSE,
+	message.MsgTypeAuthRej:                     AUTHENTICATION_REJECT,
+	message.MsgTypeAuthFailure:                 AUTHENTICATION_FAILURE,
+	message.MsgTypeAuthResult:                  AUTHENTICATION_RESULT,
+	message.MsgTypeIdReq:                       IDENTITY_REQUEST,
+	message.MsgTypeIdRsp:                       IDENTITY_RESPONSE,
+	message.MsgTypeSecModeCmd:                  SECURITY_MODE_COMMAND,
+	message.MsgTypeSecModeComplete:             SECURITY_MODE_COMPLETE,
+	message.MsgTypeSecModeRej:                  SECURITY_MODE_REJECT,
+	message.MsgTypeStatus5GMM:                  STATUS_5GMM,
+	message.MsgTypeNotif:                       NOTIFICATION,
+	message.MsgTypeNotifRsp:                    NOTIFICATION_RESPONSE,
+	message.MsgTypeULNASTransport:              UL_NAS_TRANSPORT,
+	message.MsgTypeDLNASTransport:              DL_NAS_TRANSPORT,
+	message.MsgTypeRelayKeyReq:                 RELAY_KEY_REQUEST,
+	message.MsgTypeRelayKeyAccept:              RELAY_KEY_ACCEPT,
+	message.MsgTypeRelayKeyRej:                 RELAY_KEY_REJECT,
+	message.MsgTypeRelayAuthReq:                RELAY_AUTHENTICATION_REQUEST,
+	message.MsgTypeRelayAuthRsp:                RELAY_AUTHENTICATION_RESPONSE,
 }
 
-func getMessageStrFromGmmMessage(msg *nas.Message) IeFromGmmMessage {
-	ie := IeFromGmmMessage{nasMessageType: "Unknown gmm message"}
+// metricNameOf returns the "name" label value for a message type, falling back
+// to UNKNOWN_GMM_MESSAGE for GSM messages and for types this package does not
+// know about.
+func metricNameOf(msgType message.MsgType) string {
+	if name, ok := msgTypeToMetricName[msgType]; ok {
+		return name
+	}
 
-	if msg == nil || msg.GmmMessage == nil {
+	return UNKNOWN_GMM_MESSAGE
+}
+
+type IeFromGmmMessage struct {
+	nasMessageType string
+	cause          *nasie.Cause5GMM
+}
+
+func getMessageStrFromGmmMessage(msg message.Message) IeFromGmmMessage {
+	ie := IeFromGmmMessage{nasMessageType: UNKNOWN_GMM_MESSAGE}
+
+	if msg == nil {
 		return ie
 	}
 
-	switch {
-	case msg.AuthenticationRequest != nil:
-		ie.nasMessageType = AUTHENTICATION_REQUEST
-	case msg.AuthenticationResponse != nil:
-		ie.nasMessageType = AUTHENTICATION_RESPONSE
-	case msg.AuthenticationResult != nil:
-		ie.nasMessageType = AUTHENTICATION_RESULT
-	case msg.AuthenticationFailure != nil:
-		ie.nasMessageType = AUTHENTICATION_FAILURE
-		ie.cause = msg.AuthenticationFailure.Cause5GMM
-	case msg.AuthenticationReject != nil:
-		ie.nasMessageType = AUTHENTICATION_REJECT
-	case msg.RegistrationRequest != nil:
-		ie.nasMessageType = REGISTRATION_REQUEST
-	case msg.RegistrationAccept != nil:
-		ie.nasMessageType = REGISTRATION_ACCEPT
-	case msg.RegistrationComplete != nil:
-		ie.nasMessageType = REGISTRATION_COMPLETE
-	case msg.RegistrationReject != nil:
-		ie.nasMessageType = REGISTRATION_REJECT
-		ie.cause = msg.RegistrationReject.Cause5GMM
-	case msg.ULNASTransport != nil:
-		ie.nasMessageType = UL_NAS_TRANSPORT
-	case msg.DLNASTransport != nil:
-		ie.nasMessageType = DL_NAS_TRANSPORT
-		ie.cause = *msg.DLNASTransport.Cause5GMM
-	case msg.DeregistrationRequestUEOriginatingDeregistration != nil:
-		ie.nasMessageType = DEREGISTRATION_REQUEST_UE_ORIGINATING_DEREGISTRATION
-	case msg.DeregistrationAcceptUEOriginatingDeregistration != nil:
-		ie.nasMessageType = DEREGISTRATION_ACCEPT_UE_ORIGINATING_DEREGISTRATION
-	case msg.DeregistrationRequestUETerminatedDeregistration != nil:
-		ie.nasMessageType = DEREGISTRATION_REQUEST_UE_TERMINATED_DEREGISTRATION
-		ie.cause = *msg.DeregistrationRequestUETerminatedDeregistration.Cause5GMM
-	case msg.DeregistrationAcceptUETerminatedDeregistration != nil:
-		ie.nasMessageType = DEREGISTRATION_ACCEPT_UE_TERMINATED_DEREGISTRATION
-	case msg.ServiceRequest != nil:
-		ie.nasMessageType = SERVICE_REQUEST
-	case msg.ServiceAccept != nil:
-		ie.nasMessageType = SERVICE_ACCEPT
-	case msg.ServiceReject != nil:
-		ie.nasMessageType = SERVICE_REJECT
-		ie.cause = msg.ServiceReject.Cause5GMM
-	case msg.ConfigurationUpdateCommand != nil:
-		ie.nasMessageType = CONFIGURATION_UPDATE_COMMAND
-	case msg.ConfigurationUpdateComplete != nil:
-		ie.nasMessageType = CONFIGURATION_UPDATE_COMPLETE
-	case msg.IdentityRequest != nil:
-		ie.nasMessageType = IDENTITY_REQUEST
-	case msg.IdentityResponse != nil:
-		ie.nasMessageType = IDENTITY_RESPONSE
-	case msg.Notification != nil:
-		ie.nasMessageType = NOTIFICATION
-	case msg.NotificationResponse != nil:
-		ie.nasMessageType = NOTIFICATION_RESPONSE
-	case msg.SecurityModeCommand != nil:
-		ie.nasMessageType = SECURITY_MODE_COMMAND
-	case msg.SecurityModeComplete != nil:
-		ie.nasMessageType = SECURITY_MODE_COMPLETE
-	case msg.SecurityModeReject != nil:
-		ie.nasMessageType = SECURITY_MODE_REJECT
-		ie.cause = msg.SecurityModeReject.Cause5GMM
-	case msg.SecurityProtected5GSNASMessage != nil:
-		ie.nasMessageType = SECURITY_PROTECTED_5GS_NAS_MESSAGE
-	case msg.Status5GMM != nil:
-		ie.nasMessageType = STATUS_5GMM
-		ie.cause = msg.Status5GMM.Cause5GMM
+	ie.nasMessageType = metricNameOf(msg.MsgType())
+
+	// A typed-nil pointer stored in the interface passes the msg == nil check
+	// above and survives MsgType(), but would panic on the field accesses
+	// below. Counting it under its message name with no cause is enough.
+	if v := reflect.ValueOf(msg); v.Kind() == reflect.Pointer && v.IsNil() {
+		return ie
+	}
+
+	// Only the 5GMM messages carrying a Cause5GMM IE need a case here, the
+	// message name is already resolved above.
+	switch m := msg.(type) {
+	case *message.AuthFailure:
+		ie.cause = m.Cause5GMM
+	case *message.RegRej:
+		ie.cause = m.Cause5GMM
+	case *message.DLNASTransport:
+		ie.cause = m.Cause5GMM
+	case *message.DeregReqUETerm:
+		ie.cause = m.Cause5GMM
+	case *message.SvcRej:
+		ie.cause = m.Cause5GMM
+	case *message.SecModeRej:
+		ie.cause = m.Cause5GMM
+	case *message.Status5GMM:
+		ie.cause = m.Cause5GMM
 	}
 	return ie
 }

--- a/metrics/nas/message_test.go
+++ b/metrics/nas/message_test.go
@@ -1,0 +1,143 @@
+package nas
+
+import (
+	"testing"
+
+	nasie "github.com/free5gc/nas/ie"
+	"github.com/free5gc/nas/message"
+)
+
+// The 5GMM message types of TS 24.501 table 9.7.1 all sit below this value,
+// the 5GSM ones start at 0xc1. github.com/free5gc/nas encodes the same split
+// in its MsgType constants but exposes no predicate for it.
+const gsmMsgTypeLowerBound = message.MsgType(0x80)
+
+// TestMsgTypeCoverage fails when github.com/free5gc/nas gains a 5GMM message
+// type that msgTypeToMetricName does not map, which would otherwise silently
+// start reporting the new message as UNKNOWN_GMM_MESSAGE.
+func TestMsgTypeCoverage(t *testing.T) {
+	for i := range int(gsmMsgTypeLowerBound) {
+		msgType := message.MsgType(i)
+
+		// An empty name means the upstream module does not know this type.
+		if msgType.String() == "" {
+			continue
+		}
+
+		if _, ok := msgTypeToMetricName[msgType]; !ok {
+			t.Errorf("5GMM message type %s (%d) has no entry in msgTypeToMetricName",
+				msgType, i)
+		}
+	}
+}
+
+// TestMsgTypeToMetricNameIsInjective guards against two message types sharing a
+// metric name, which would silently merge their counters.
+func TestMsgTypeToMetricNameIsInjective(t *testing.T) {
+	seen := make(map[string]message.MsgType, len(msgTypeToMetricName))
+
+	for msgType, name := range msgTypeToMetricName {
+		if previous, ok := seen[name]; ok {
+			t.Errorf("metric name %q is used by both %s and %s", name, previous, msgType)
+			continue
+		}
+		seen[name] = msgType
+	}
+}
+
+// TestMetricNameOf pins the label values that dashboards and alerting rules
+// depend on. They must not follow message.MsgType.String() of the upstream
+// module: those names are shorter and would break every existing query.
+func TestMetricNameOf(t *testing.T) {
+	testCases := []struct {
+		msgType  message.MsgType
+		expected string
+	}{
+		{message.MsgTypeAuthReq, AUTHENTICATION_REQUEST},
+		{message.MsgTypeRegReq, REGISTRATION_REQUEST},
+		{message.MsgTypeRegRej, REGISTRATION_REJECT},
+		{message.MsgTypeDeregReqUETerm, DEREGISTRATION_REQUEST_UE_TERMINATED_DEREGISTRATION},
+		{message.MsgTypeSvcRej, SERVICE_REJECT},
+		{message.MsgTypeSecModeCmd, SECURITY_MODE_COMMAND},
+		{message.MsgTypeCfgUpdateCmd, CONFIGURATION_UPDATE_COMMAND},
+		{message.MsgTypeIdReq, IDENTITY_REQUEST},
+		{message.MsgTypeNotif, NOTIFICATION},
+		{message.MsgTypeStatus5GMM, STATUS_5GMM},
+		{message.MsgTypeULNASTransport, UL_NAS_TRANSPORT},
+		// 5GSM messages are not counted by this collector.
+		{message.MsgTypePDUSessEstReq, UNKNOWN_GMM_MESSAGE},
+		// Unassigned message type.
+		{message.MsgType(0), UNKNOWN_GMM_MESSAGE},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.expected, func(t *testing.T) {
+			if name := metricNameOf(testCase.msgType); name != testCase.expected {
+				t.Errorf("expected name: %q, output name: %q", testCase.expected, name)
+			}
+		})
+	}
+}
+
+// TestGetMessageStrFromGmmMessage covers the message name and Cause5GMM
+// extraction, including the nil shapes that reach this package from a deferred
+// call whose message was never decoded.
+func TestGetMessageStrFromGmmMessage(t *testing.T) {
+	causeValue := uint8(3) // Cause5GMM_IllegalUE
+
+	regRejWithCause := &message.RegRej{}
+	regRejWithCause.Cause5GMM = &nasie.Cause5GMM{Value: causeValue}
+
+	testCases := []struct {
+		name          string
+		msg           message.Message
+		expectedName  string
+		expectedCause *uint8
+	}{
+		{
+			name:         "nil interface",
+			msg:          nil,
+			expectedName: UNKNOWN_GMM_MESSAGE,
+		},
+		{
+			name:         "typed nil pointer",
+			msg:          (*message.RegRej)(nil),
+			expectedName: REGISTRATION_REJECT,
+		},
+		{
+			name:         "message without cause IE",
+			msg:          &message.RegReq{},
+			expectedName: REGISTRATION_REQUEST,
+		},
+		{
+			name:         "message with absent cause IE",
+			msg:          &message.RegRej{},
+			expectedName: REGISTRATION_REJECT,
+		},
+		{
+			name:          "message with cause IE",
+			msg:           regRejWithCause,
+			expectedName:  REGISTRATION_REJECT,
+			expectedCause: &causeValue,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ie := getMessageStrFromGmmMessage(testCase.msg)
+
+			if ie.nasMessageType != testCase.expectedName {
+				t.Errorf("expected name: %q, output name: %q", testCase.expectedName, ie.nasMessageType)
+			}
+
+			switch {
+			case testCase.expectedCause == nil && ie.cause != nil:
+				t.Errorf("expected no cause, output cause: %d", ie.cause.Value)
+			case testCase.expectedCause != nil && ie.cause == nil:
+				t.Errorf("expected cause: %d, output no cause", *testCase.expectedCause)
+			case testCase.expectedCause != nil && ie.cause.Value != *testCase.expectedCause:
+				t.Errorf("expected cause: %d, output cause: %d", *testCase.expectedCause, ie.cause.Value)
+			}
+		})
+	}
+}

--- a/metrics/nas/types.go
+++ b/metrics/nas/types.go
@@ -17,8 +17,14 @@ const (
 	CAUSE_LABEL  = "cause"
 )
 
-// These values are tied to the metrics NAS message type
+// These values are tied to the metrics NAS message type.
+//
+// They are the public label vocabulary of the NAS metrics: renaming any of
+// them breaks existing dashboards and alerting rules, so they are pinned here
+// rather than derived from the message.MsgType names of github.com/free5gc/nas.
+// msgTypeToMetricName in message.go maps upstream message types onto them.
 const (
+	UNKNOWN_GMM_MESSAGE                                  = "Unknown gmm message"
 	AUTHENTICATION_REQUEST                               = "AuthenticationRequest"
 	AUTHENTICATION_RESPONSE                              = "AuthenticationResponse"
 	AUTHENTICATION_RESULT                                = "AuthenticationResult"
@@ -51,6 +57,19 @@ const (
 	SECURITY_MODE_REJECT                                 = "SecurityModeReject"
 	SECURITY_PROTECTED_5GS_NAS_MESSAGE                   = "SecurityProtected5GSNASMessage"
 	STATUS_5GMM                                          = "Status5GMM"
+
+	// 5GMM message types that the previous nas API did not expose and that
+	// therefore used to be counted as UNKNOWN_GMM_MESSAGE. Adding them is
+	// additive: no pre-existing label value changes meaning.
+	CONTROL_PLANE_SERVICE_REQUEST                  = "ControlPlaneServiceRequest"
+	NETWORK_SLICE_SPECIFIC_AUTHENTICATION_COMMAND  = "NetworkSliceSpecificAuthenticationCommand"
+	NETWORK_SLICE_SPECIFIC_AUTHENTICATION_COMPLETE = "NetworkSliceSpecificAuthenticationComplete"
+	NETWORK_SLICE_SPECIFIC_AUTHENTICATION_RESULT   = "NetworkSliceSpecificAuthenticationResult"
+	RELAY_KEY_REQUEST                              = "RelayKeyRequest"
+	RELAY_KEY_ACCEPT                               = "RelayKeyAccept"
+	RELAY_KEY_REJECT                               = "RelayKeyReject"
+	RELAY_AUTHENTICATION_REQUEST                   = "RelayAuthenticationRequest"
+	RELAY_AUTHENTICATION_RESPONSE                  = "RelayAuthenticationResponse"
 )
 
 // Additional error causes

--- a/metrics/ngap/error_message.go
+++ b/metrics/ngap/error_message.go
@@ -1,198 +1,165 @@
+// Package ngap: NGAP message metrics, built against the new
+// github.com/free5gc/ngap API (ie package).
 package ngap
 
 import (
-	"github.com/free5gc/ngap/ngapType"
+	"github.com/free5gc/ngap/aper"
+	ngapie "github.com/free5gc/ngap/ie"
 )
 
-func getCauseRadioNetworkErrorStr(cause *ngapType.CauseRadioNetwork) string {
-	switch cause.Value {
-	case ngapType.CauseRadioNetworkPresentUnspecified:
-		return "RadioNetwork : Unspecified"
-	case ngapType.CauseRadioNetworkPresentTxnrelocoverallExpiry:
-		return "RadioNetwork : TxnrelocoverallExpiry"
-	case ngapType.CauseRadioNetworkPresentSuccessfulHandover:
-		return "RadioNetwork : SuccessfulHandover"
-	case ngapType.CauseRadioNetworkPresentReleaseDueToNgranGeneratedReason:
-		return "RadioNetwork : ReleaseDueToNgranGeneratedReason"
-	case ngapType.CauseRadioNetworkPresentReleaseDueTo5gcGeneratedReason:
-		return "RadioNetwork : ReleaseDueTo5gcGeneratedReason"
-	case ngapType.CauseRadioNetworkPresentHandoverCancelled:
-		return "RadioNetwork : HandoverCancelled"
-	case ngapType.CauseRadioNetworkPresentPartialHandover:
-		return "RadioNetwork : PartialHandover"
-	case ngapType.CauseRadioNetworkPresentHoFailureInTarget5GCNgranNodeOrTargetSystem:
-		return "RadioNetwork : HoFailureInTarget5GCNgranNodeOrTargetSystem"
-	case ngapType.CauseRadioNetworkPresentHoTargetNotAllowed:
-		return "RadioNetwork : HoTargetNotAllowed"
-	case ngapType.CauseRadioNetworkPresentTngrelocoverallExpiry:
-		return "RadioNetwork : TngrelocoverallExpiry"
-	case ngapType.CauseRadioNetworkPresentTngrelocprepExpiry:
-		return "RadioNetwork : TngrelocprepExpiry"
-	case ngapType.CauseRadioNetworkPresentCellNotAvailable:
-		return "RadioNetwork : CellNotAvailable"
-	case ngapType.CauseRadioNetworkPresentUnknownTargetID:
-		return "RadioNetwork : UnknownTargetID"
-	case ngapType.CauseRadioNetworkPresentNoRadioResourcesAvailableInTargetCell:
-		return "RadioNetwork : NoRadioResourcesAvailableInTargetCell"
-	case ngapType.CauseRadioNetworkPresentUnknownLocalUENGAPID:
-		return "RadioNetwork : UnknownLocalUENGAPID"
-	case ngapType.CauseRadioNetworkPresentInconsistentRemoteUENGAPID:
-		return "RadioNetwork : InconsistentRemoteUENGAPID"
-	case ngapType.CauseRadioNetworkPresentHandoverDesirableForRadioReason:
-		return "RadioNetwork : HandoverDesirableForRadioReason"
-	case ngapType.CauseRadioNetworkPresentTimeCriticalHandover:
-		return "RadioNetwork : TimeCriticalHandover"
-	case ngapType.CauseRadioNetworkPresentResourceOptimisationHandover:
-		return "RadioNetwork : ResourceOptimisationHandover"
-	case ngapType.CauseRadioNetworkPresentReduceLoadInServingCell:
-		return "RadioNetwork : ReduceLoadInServingCell"
-	case ngapType.CauseRadioNetworkPresentUserInactivity:
-		return "RadioNetwork : UserInactivity"
-	case ngapType.CauseRadioNetworkPresentRadioConnectionWithUeLost:
-		return "RadioNetwork : RadioConnectionWithUeLost"
-	case ngapType.CauseRadioNetworkPresentRadioResourcesNotAvailable:
-		return "RadioNetwork : RadioResourcesNotAvailable"
-	case ngapType.CauseRadioNetworkPresentInvalidQosCombination:
-		return "RadioNetwork : InvalidQosCombination"
-	case ngapType.CauseRadioNetworkPresentFailureInRadioInterfaceProcedure:
-		return "RadioNetwork : FailureInRadioInterfaceProcedure"
-	case ngapType.CauseRadioNetworkPresentInteractionWithOtherProcedure:
-		return "RadioNetwork : InteractionWithOtherProcedure"
-	case ngapType.CauseRadioNetworkPresentUnknownPDUSessionID:
-		return "RadioNetwork : UnknownPDUSessionID"
-	case ngapType.CauseRadioNetworkPresentUnkownQosFlowID:
-		return "RadioNetwork : UnkownQosFlowID"
-	case ngapType.CauseRadioNetworkPresentMultiplePDUSessionIDInstances:
-		return "RadioNetwork : MultiplePDUSessionIDInstances"
-	case ngapType.CauseRadioNetworkPresentMultipleQosFlowIDInstances:
-		return "RadioNetwork : MultipleQosFlowIDInstances"
-	case ngapType.CauseRadioNetworkPresentEncryptionAndOrIntegrityProtectionAlgorithmsNotSupported:
-		return "RadioNetwork : EncryptionAndOrIntegrityProtectionAlgorithmsNotSupported"
-	case ngapType.CauseRadioNetworkPresentNgIntraSystemHandoverTriggered:
-		return "RadioNetwork : NgIntraSystemHandoverTriggered"
-	case ngapType.CauseRadioNetworkPresentNgInterSystemHandoverTriggered:
-		return "RadioNetwork : NgInterSystemHandoverTriggered"
-	case ngapType.CauseRadioNetworkPresentXnHandoverTriggered:
-		return "RadioNetwork : XnHandoverTriggered"
-	case ngapType.CauseRadioNetworkPresentNotSupported5QIValue:
-		return "RadioNetwork : NotSupported5QIValue"
-	case ngapType.CauseRadioNetworkPresentUeContextTransfer:
-		return "RadioNetwork : UeContextTransfer"
-	case ngapType.CauseRadioNetworkPresentImsVoiceEpsFallbackOrRatFallbackTriggered:
-		return "RadioNetwork : ImsVoiceEpsFallbackOrRatFallbackTriggered"
-	case ngapType.CauseRadioNetworkPresentUpIntegrityProtectionNotPossible:
-		return "RadioNetwork : UpIntegrityProtectionNotPossible"
-	case ngapType.CauseRadioNetworkPresentUpConfidentialityProtectionNotPossible:
-		return "RadioNetwork : UpConfidentialityProtectionNotPossible"
-	case ngapType.CauseRadioNetworkPresentSliceNotSupported:
-		return "RadioNetwork : SliceNotSupported"
-	case ngapType.CauseRadioNetworkPresentUeInRrcInactiveStateNotReachable:
-		return "RadioNetwork : UeInRrcInactiveStateNotReachable"
-	case ngapType.CauseRadioNetworkPresentRedirection:
-		return "RadioNetwork : Redirection"
-	case ngapType.CauseRadioNetworkPresentResourcesNotAvailableForTheSlice:
-		return "RadioNetwork : ResourcesNotAvailableForTheSlice"
-	case ngapType.CauseRadioNetworkPresentUeMaxIntegrityProtectedDataRateReason:
-		return "RadioNetwork : UeMaxIntegrityProtectedDataRateReason"
-	case ngapType.CauseRadioNetworkPresentReleaseDueToCnDetectedMobility:
-		return "RadioNetwork : ReleaseDueToCnDetectedMobility"
-	case ngapType.CauseRadioNetworkPresentN26InterfaceNotAvailable:
-		return "RadioNetwork : N26InterfaceNotAvailable"
-	case ngapType.CauseRadioNetworkPresentReleaseDueToPreEmption:
-		return "RadioNetwork : ReleaseDueToPreEmption"
-	default:
-		return "unknown cause"
+// The cause maps below pin the "cause" label of the NGAP metrics to this
+// package instead of delegating to ngapie.Cause.String(). Two reasons:
+//
+//   - The label values are consumed by dashboards and alerting rules, while the
+//     strings of github.com/free5gc/ngap belong to that module and may change
+//     with no compilation error here.
+//   - ngapie.Cause.String() renders values it does not know as
+//     "Unregconized <group> cause value(<n>)", which turns a malformed peer into
+//     unbounded label cardinality. An unknown value maps to the fixed
+//     UNKNOWN_CAUSE_ERR here.
+//
+// Every entry is "<group> : <constant name without the CauseXxxPresent prefix>",
+// matching the values emitted before the migration to the new ngap API.
+var causeRadioNetworkStr = map[aper.Enumerated]string{
+	ngapie.CauseRadioNetworkPresentUnspecified:                      "RadioNetwork : Unspecified",
+	ngapie.CauseRadioNetworkPresentTxnrelocoverallExpiry:            "RadioNetwork : TxnrelocoverallExpiry",
+	ngapie.CauseRadioNetworkPresentSuccessfulHandover:               "RadioNetwork : SuccessfulHandover",
+	ngapie.CauseRadioNetworkPresentReleaseDueToNgranGeneratedReason: "RadioNetwork : ReleaseDueToNgranGeneratedReason",
+	ngapie.CauseRadioNetworkPresentReleaseDueTo5gcGeneratedReason:   "RadioNetwork : ReleaseDueTo5gcGeneratedReason",
+	ngapie.CauseRadioNetworkPresentHandoverCancelled:                "RadioNetwork : HandoverCancelled",
+	ngapie.CauseRadioNetworkPresentPartialHandover:                  "RadioNetwork : PartialHandover",
+	ngapie.CauseRadioNetworkPresentHoFailureInTarget5GCNgranNodeOrTargetSystem: "RadioNetwork : " +
+		"HoFailureInTarget5GCNgranNodeOrTargetSystem",
+	ngapie.CauseRadioNetworkPresentHoTargetNotAllowed:    "RadioNetwork : HoTargetNotAllowed",
+	ngapie.CauseRadioNetworkPresentTngrelocoverallExpiry: "RadioNetwork : TngrelocoverallExpiry",
+	ngapie.CauseRadioNetworkPresentTngrelocprepExpiry:    "RadioNetwork : TngrelocprepExpiry",
+	ngapie.CauseRadioNetworkPresentCellNotAvailable:      "RadioNetwork : CellNotAvailable",
+	ngapie.CauseRadioNetworkPresentUnknownTargetID:       "RadioNetwork : UnknownTargetID",
+	ngapie.CauseRadioNetworkPresentNoRadioResourcesAvailableInTargetCell: "RadioNetwork : " +
+		"NoRadioResourcesAvailableInTargetCell",
+	ngapie.CauseRadioNetworkPresentUnknownLocalUENGAPID:             "RadioNetwork : UnknownLocalUENGAPID",
+	ngapie.CauseRadioNetworkPresentInconsistentRemoteUENGAPID:       "RadioNetwork : InconsistentRemoteUENGAPID",
+	ngapie.CauseRadioNetworkPresentHandoverDesirableForRadioReason:  "RadioNetwork : HandoverDesirableForRadioReason",
+	ngapie.CauseRadioNetworkPresentTimeCriticalHandover:             "RadioNetwork : TimeCriticalHandover",
+	ngapie.CauseRadioNetworkPresentResourceOptimisationHandover:     "RadioNetwork : ResourceOptimisationHandover",
+	ngapie.CauseRadioNetworkPresentReduceLoadInServingCell:          "RadioNetwork : ReduceLoadInServingCell",
+	ngapie.CauseRadioNetworkPresentUserInactivity:                   "RadioNetwork : UserInactivity",
+	ngapie.CauseRadioNetworkPresentRadioConnectionWithUeLost:        "RadioNetwork : RadioConnectionWithUeLost",
+	ngapie.CauseRadioNetworkPresentRadioResourcesNotAvailable:       "RadioNetwork : RadioResourcesNotAvailable",
+	ngapie.CauseRadioNetworkPresentInvalidQosCombination:            "RadioNetwork : InvalidQosCombination",
+	ngapie.CauseRadioNetworkPresentFailureInRadioInterfaceProcedure: "RadioNetwork : FailureInRadioInterfaceProcedure",
+	ngapie.CauseRadioNetworkPresentInteractionWithOtherProcedure:    "RadioNetwork : InteractionWithOtherProcedure",
+	ngapie.CauseRadioNetworkPresentUnknownPDUSessionID:              "RadioNetwork : UnknownPDUSessionID",
+	ngapie.CauseRadioNetworkPresentUnkownQosFlowID:                  "RadioNetwork : UnkownQosFlowID",
+	ngapie.CauseRadioNetworkPresentMultiplePDUSessionIDInstances:    "RadioNetwork : MultiplePDUSessionIDInstances",
+	ngapie.CauseRadioNetworkPresentMultipleQosFlowIDInstances:       "RadioNetwork : MultipleQosFlowIDInstances",
+	ngapie.CauseRadioNetworkPresentEncryptionAndOrIntegrityProtectionAlgorithmsNotSupported: "RadioNetwork : " +
+		"EncryptionAndOrIntegrityProtectionAlgorithmsNotSupported",
+	ngapie.CauseRadioNetworkPresentNgIntraSystemHandoverTriggered: "RadioNetwork : NgIntraSystemHandoverTriggered",
+	ngapie.CauseRadioNetworkPresentNgInterSystemHandoverTriggered: "RadioNetwork : NgInterSystemHandoverTriggered",
+	ngapie.CauseRadioNetworkPresentXnHandoverTriggered:            "RadioNetwork : XnHandoverTriggered",
+	ngapie.CauseRadioNetworkPresentNotSupported5QIValue:           "RadioNetwork : NotSupported5QIValue",
+	ngapie.CauseRadioNetworkPresentUeContextTransfer:              "RadioNetwork : UeContextTransfer",
+	ngapie.CauseRadioNetworkPresentImsVoiceEpsFallbackOrRatFallbackTriggered: "RadioNetwork : " +
+		"ImsVoiceEpsFallbackOrRatFallbackTriggered",
+	ngapie.CauseRadioNetworkPresentUpIntegrityProtectionNotPossible: "RadioNetwork : UpIntegrityProtectionNotPossible",
+	ngapie.CauseRadioNetworkPresentUpConfidentialityProtectionNotPossible: "RadioNetwork : " +
+		"UpConfidentialityProtectionNotPossible",
+	ngapie.CauseRadioNetworkPresentSliceNotSupported: "RadioNetwork : SliceNotSupported",
+	ngapie.CauseRadioNetworkPresentUeInRrcInactiveStateNotReachable: "RadioNetwork : " +
+		"UeInRrcInactiveStateNotReachable",
+	ngapie.CauseRadioNetworkPresentRedirection: "RadioNetwork : Redirection",
+	ngapie.CauseRadioNetworkPresentResourcesNotAvailableForTheSlice: "RadioNetwork : " +
+		"ResourcesNotAvailableForTheSlice",
+	ngapie.CauseRadioNetworkPresentUeMaxIntegrityProtectedDataRateReason: "RadioNetwork : " +
+		"UeMaxIntegrityProtectedDataRateReason",
+	ngapie.CauseRadioNetworkPresentReleaseDueToCnDetectedMobility: "RadioNetwork : ReleaseDueToCnDetectedMobility",
+	ngapie.CauseRadioNetworkPresentN26InterfaceNotAvailable:       "RadioNetwork : N26InterfaceNotAvailable",
+	ngapie.CauseRadioNetworkPresentReleaseDueToPreEmption:         "RadioNetwork : ReleaseDueToPreEmption",
+
+	// Values the previous ngapType package did not define. Adding them is
+	// additive: they used to be reported as UNKNOWN_CAUSE_ERR.
+	ngapie.CauseRadioNetworkPresentMultipleLocationReportingReferenceIDInstances: "RadioNetwork : " +
+		"MultipleLocationReportingReferenceIDInstances",
+	ngapie.CauseRadioNetworkPresentRsnNotAvailableForTheUp:    "RadioNetwork : RsnNotAvailableForTheUp",
+	ngapie.CauseRadioNetworkPresentNpnAccessDenied:            "RadioNetwork : NpnAccessDenied",
+	ngapie.CauseRadioNetworkPresentCagOnlyAccessDenied:        "RadioNetwork : CagOnlyAccessDenied",
+	ngapie.CauseRadioNetworkPresentInsufficientUeCapabilities: "RadioNetwork : InsufficientUeCapabilities",
+	ngapie.CauseRadioNetworkPresentRedcapUeNotSupported:       "RadioNetwork : RedcapUeNotSupported",
+	ngapie.CauseRadioNetworkPresentUnknownMBSSessionID:        "RadioNetwork : UnknownMBSSessionID",
+	ngapie.CauseRadioNetworkPresentIndicatedMBSSessionAreaInformationNotServedByTheGNB: "RadioNetwork : " +
+		"IndicatedMBSSessionAreaInformationNotServedByTheGNB",
+	ngapie.CauseRadioNetworkPresentInconsistentSliceInfoForTheSession: "RadioNetwork : InconsistentSliceInfoForTheSession",
+	ngapie.CauseRadioNetworkPresentMisalignedAssociationForMulticastUnicast: "RadioNetwork : " +
+		"MisalignedAssociationForMulticastUnicast",
+}
+
+var causeTransportStr = map[aper.Enumerated]string{
+	ngapie.CauseTransportPresentTransportResourceUnavailable: "Transport : TransportResourceUnavailable",
+	ngapie.CauseTransportPresentUnspecified:                  "Transport : Unspecified",
+}
+
+var causeNasStr = map[aper.Enumerated]string{
+	ngapie.CauseNasPresentNormalRelease:         "Nas : NormalRelease",
+	ngapie.CauseNasPresentAuthenticationFailure: "Nas : AuthenticationFailure",
+	ngapie.CauseNasPresentDeregister:            "Nas : Deregister",
+	ngapie.CauseNasPresentUnspecified:           "Nas : Unspecified",
+
+	// Not defined by the previous ngapType package, see above.
+	ngapie.CauseNasPresentUENotInPLMNServingArea: "Nas : UENotInPLMNServingArea",
+}
+
+var causeProtocolStr = map[aper.Enumerated]string{
+	ngapie.CauseProtocolPresentTransferSyntaxError:                "Protocol : TransferSyntaxError",
+	ngapie.CauseProtocolPresentAbstractSyntaxErrorReject:          "Protocol : AbstractSyntaxErrorReject",
+	ngapie.CauseProtocolPresentAbstractSyntaxErrorIgnoreAndNotify: "Protocol : AbstractSyntaxErrorIgnoreAndNotify",
+	ngapie.CauseProtocolPresentMessageNotCompatibleWithReceiverState: "Protocol : " +
+		"MessageNotCompatibleWithReceiverState",
+	ngapie.CauseProtocolPresentSemanticError: "Protocol : SemanticError",
+	ngapie.CauseProtocolPresentAbstractSyntaxErrorFalselyConstructedMessage: "Protocol : " +
+		"AbstractSyntaxErrorFalselyConstructedMessage",
+	ngapie.CauseProtocolPresentUnspecified: "Protocol : Unspecified",
+}
+
+var causeMiscStr = map[aper.Enumerated]string{
+	ngapie.CauseMiscPresentControlProcessingOverload:             "Misc : ControlProcessingOverload",
+	ngapie.CauseMiscPresentNotEnoughUserPlaneProcessingResources: "Misc : NotEnoughUserPlaneProcessingResources",
+	ngapie.CauseMiscPresentHardwareFailure:                       "Misc : HardwareFailure",
+	ngapie.CauseMiscPresentOmIntervention:                        "Misc : OmIntervention",
+	// Upstream renamed this value to CauseMiscPresentUnknownPLMNOrSNPN, the
+	// label value stays as it was to keep existing queries working.
+	ngapie.CauseMiscPresentUnknownPLMNOrSNPN: "Misc : UnknownPLMN",
+	ngapie.CauseMiscPresentUnspecified:       "Misc : Unspecified",
+}
+
+func getCauseStr(causeStr map[aper.Enumerated]string, value aper.Enumerated) string {
+	if str, ok := causeStr[value]; ok {
+		return str
 	}
+
+	return UNKNOWN_CAUSE_ERR
 }
 
-func getCauseTransportErrorStr(cause *ngapType.CauseTransport) string {
-	switch cause.Value {
-	case ngapType.CauseTransportPresentTransportResourceUnavailable:
-		return "Transport : TransportResourceUnavailable"
-	case ngapType.CauseTransportPresentUnspecified:
-		return "Transport : Unspecified"
-	default:
-		return "unknown cause"
+func GetCauseErrorStr(cause *ngapie.Cause) string {
+	if cause == nil {
+		return UNKNOWN_NGAP_TYPE_CAUSE_ERR
 	}
-}
 
-func getCauseNasErrorStr(cause *ngapType.CauseNas) string {
-	switch cause.Value {
-	case ngapType.CauseNasPresentNormalRelease:
-		return "Nas : NormalRelease"
-	case ngapType.CauseNasPresentAuthenticationFailure:
-		return "Nas : AuthenticationFailure"
-	case ngapType.CauseNasPresentDeregister:
-		return "Nas : Deregister"
-	case ngapType.CauseNasPresentUnspecified:
-		return "Nas : Unspecified"
-	default:
-		return "unknown cause"
-	}
-}
-
-func getCauseProtocolErrorStr(cause *ngapType.CauseProtocol) string {
-	switch cause.Value {
-	case ngapType.CauseProtocolPresentTransferSyntaxError:
-		return "Protocol : TransferSyntaxError"
-	case ngapType.CauseProtocolPresentAbstractSyntaxErrorReject:
-		return "Protocol : AbstractSyntaxErrorReject"
-	case ngapType.CauseProtocolPresentAbstractSyntaxErrorIgnoreAndNotify:
-		return "Protocol : AbstractSyntaxErrorIgnoreAndNotify"
-	case ngapType.CauseProtocolPresentMessageNotCompatibleWithReceiverState:
-		return "Protocol : MessageNotCompatibleWithReceiverState"
-	case ngapType.CauseProtocolPresentSemanticError:
-		return "Protocol : SemanticError"
-	case ngapType.CauseProtocolPresentAbstractSyntaxErrorFalselyConstructedMessage:
-		return "Protocol : AbstractSyntaxErrorFalselyConstructedMessage"
-	case ngapType.CauseProtocolPresentUnspecified:
-		return "Protocol : Unspecified"
-	default:
-		return "unknown cause"
-	}
-}
-
-func getCauseMiscErrorStr(cause *ngapType.CauseMisc) string {
-	switch cause.Value {
-	case ngapType.CauseMiscPresentControlProcessingOverload:
-		return "Misc : ControlProcessingOverload"
-	case ngapType.CauseMiscPresentNotEnoughUserPlaneProcessingResources:
-		return "Misc : NotEnoughUserPlaneProcessingResources"
-	case ngapType.CauseMiscPresentHardwareFailure:
-		return "Misc : HardwareFailure"
-	case ngapType.CauseMiscPresentOmIntervention:
-		return "Misc : OmIntervention"
-	case ngapType.CauseMiscPresentUnknownPLMN:
-		return "Misc : UnknownPLMN"
-	case ngapType.CauseMiscPresentUnspecified:
-		return "Misc : Unspecified"
-	default:
-		return "unknown cause"
-	}
-}
-
-func getCauseChoiceExtensionsErrorStr(cause *ngapType.ProtocolIESingleContainerCauseExtIEs) string {
-	return "ChoiceExtensions : Unknown error"
-}
-
-func GetCauseErrorStr(cause *ngapType.Cause) string {
-	if cause != nil {
-		switch cause.Present {
-		case ngapType.CausePresentRadioNetwork:
-			return getCauseRadioNetworkErrorStr(cause.RadioNetwork)
-		case ngapType.CausePresentTransport:
-			return getCauseTransportErrorStr(cause.Transport)
-		case ngapType.CausePresentNas:
-			return getCauseNasErrorStr(cause.Nas)
-		case ngapType.CausePresentProtocol:
-			return getCauseProtocolErrorStr(cause.Protocol)
-		case ngapType.CausePresentMisc:
-			return getCauseMiscErrorStr(cause.Misc)
-		case ngapType.CausePresentChoiceExtensions:
-			return getCauseChoiceExtensionsErrorStr(cause.ChoiceExtensions)
-		default:
-			return UNKNOWN_NGAP_TYPE_CAUSE_ERR
-		}
+	// Only the pointer types implement ngapie.CauseAlt: Read has a pointer
+	// receiver, so a cause group value cannot be stored in Choice.
+	switch causeGroup := cause.Choice.(type) {
+	case *ngapie.CauseRadioNetwork:
+		return getCauseStr(causeRadioNetworkStr, causeGroup.Value)
+	case *ngapie.CauseTransport:
+		return getCauseStr(causeTransportStr, causeGroup.Value)
+	case *ngapie.CauseNas:
+		return getCauseStr(causeNasStr, causeGroup.Value)
+	case *ngapie.CauseProtocol:
+		return getCauseStr(causeProtocolStr, causeGroup.Value)
+	case *ngapie.CauseMisc:
+		return getCauseStr(causeMiscStr, causeGroup.Value)
+	case *ngapie.ProtocolIESingleContainerCauseExtIEs:
+		return CHOICE_EXTENSIONS_UNKNOWN_ERR
 	}
 
 	return UNKNOWN_NGAP_TYPE_CAUSE_ERR

--- a/metrics/ngap/error_message_test.go
+++ b/metrics/ngap/error_message_test.go
@@ -1,0 +1,143 @@
+package ngap
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/free5gc/ngap/aper"
+	ngapie "github.com/free5gc/ngap/ie"
+)
+
+// TestCauseStrCoverage fails when github.com/free5gc/ngap gains a cause value
+// that the maps of this package do not carry, which would otherwise silently
+// start reporting the new value as UNKNOWN_CAUSE_ERR.
+func TestCauseStrCoverage(t *testing.T) {
+	testCases := []struct {
+		group    string
+		upstream map[aper.Enumerated]string
+		local    map[aper.Enumerated]string
+	}{
+		{"RadioNetwork", ngapie.CauseRadioNetworkStrings, causeRadioNetworkStr},
+		{"Transport", ngapie.CauseTransportStrings, causeTransportStr},
+		{"Nas", ngapie.CauseNasStrings, causeNasStr},
+		{"Protocol", ngapie.CauseProtocolStrings, causeProtocolStr},
+		{"Misc", ngapie.CauseMiscStrings, causeMiscStr},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.group, func(t *testing.T) {
+			for value := range testCase.upstream {
+				if _, ok := testCase.local[value]; !ok {
+					t.Errorf("cause value %d of group %s has no entry in the local map",
+						value, testCase.group)
+				}
+			}
+		})
+	}
+}
+
+// TestGetCauseErrorStr pins the label values that dashboards and alerting rules
+// depend on, and checks that an unknown value cannot leak into the label.
+func TestGetCauseErrorStr(t *testing.T) {
+	testCases := []struct {
+		name     string
+		cause    *ngapie.Cause
+		expected string
+	}{
+		{
+			name:     "nil cause",
+			cause:    nil,
+			expected: UNKNOWN_NGAP_TYPE_CAUSE_ERR,
+		},
+		{
+			name:     "nil choice",
+			cause:    &ngapie.Cause{},
+			expected: UNKNOWN_NGAP_TYPE_CAUSE_ERR,
+		},
+		{
+			name: "radio network",
+			cause: &ngapie.Cause{Choice: &ngapie.CauseRadioNetwork{
+				Value: ngapie.CauseRadioNetworkPresentRadioConnectionWithUeLost,
+			}},
+			expected: "RadioNetwork : RadioConnectionWithUeLost",
+		},
+		{
+			name: "transport",
+			cause: &ngapie.Cause{Choice: &ngapie.CauseTransport{
+				Value: ngapie.CauseTransportPresentTransportResourceUnavailable,
+			}},
+			expected: "Transport : TransportResourceUnavailable",
+		},
+		{
+			name: "nas",
+			cause: &ngapie.Cause{Choice: &ngapie.CauseNas{
+				Value: ngapie.CauseNasPresentDeregister,
+			}},
+			expected: "Nas : Deregister",
+		},
+		{
+			name: "protocol",
+			cause: &ngapie.Cause{Choice: &ngapie.CauseProtocol{
+				Value: ngapie.CauseProtocolPresentSemanticError,
+			}},
+			expected: "Protocol : SemanticError",
+		},
+		{
+			name: "misc",
+			cause: &ngapie.Cause{Choice: &ngapie.CauseMisc{
+				Value: ngapie.CauseMiscPresentUnknownPLMNOrSNPN,
+			}},
+			expected: "Misc : UnknownPLMN",
+		},
+		{
+			name:     "choice extensions",
+			cause:    &ngapie.Cause{Choice: &ngapie.ProtocolIESingleContainerCauseExtIEs{}},
+			expected: CHOICE_EXTENSIONS_UNKNOWN_ERR,
+		},
+		{
+			name:     "value outside of the enumeration",
+			cause:    &ngapie.Cause{Choice: &ngapie.CauseRadioNetwork{Value: aper.Enumerated(9999)}},
+			expected: UNKNOWN_CAUSE_ERR,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if str := GetCauseErrorStr(testCase.cause); str != testCase.expected {
+				t.Errorf("expected cause: %q, output cause: %q", testCase.expected, str)
+			}
+		})
+	}
+}
+
+// TestCauseLabelCardinalityIsBounded walks the whole value space of every cause
+// group: no input may produce a label value carrying the numeric cause value,
+// the way ngapie.Cause.String() does for the values it does not know.
+func TestCauseLabelCardinalityIsBounded(t *testing.T) {
+	choices := []func(aper.Enumerated) ngapie.CauseAlt{
+		func(v aper.Enumerated) ngapie.CauseAlt { return &ngapie.CauseRadioNetwork{Value: v} },
+		func(v aper.Enumerated) ngapie.CauseAlt { return &ngapie.CauseTransport{Value: v} },
+		func(v aper.Enumerated) ngapie.CauseAlt { return &ngapie.CauseNas{Value: v} },
+		func(v aper.Enumerated) ngapie.CauseAlt { return &ngapie.CauseProtocol{Value: v} },
+		func(v aper.Enumerated) ngapie.CauseAlt { return &ngapie.CauseMisc{Value: v} },
+	}
+
+	labels := make(map[string]struct{})
+
+	for _, choice := range choices {
+		for value := range 256 {
+			str := GetCauseErrorStr(&ngapie.Cause{Choice: choice(aper.Enumerated(value))})
+
+			if strings.Contains(str, "Unregconized") {
+				t.Errorf("cause value %d produced the upstream fallback %q", value, str)
+			}
+
+			labels[str] = struct{}{}
+		}
+	}
+
+	// 57 + 2 + 5 + 7 + 6 known values, plus UNKNOWN_CAUSE_ERR.
+	if expected := 78; len(labels) != expected {
+		t.Errorf("expected %d distinct label values, output %d", expected, len(labels))
+	}
+}

--- a/metrics/ngap/message.go
+++ b/metrics/ngap/message.go
@@ -3,7 +3,7 @@ package ngap
 import (
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/free5gc/ngap/ngapType"
+	ngapie "github.com/free5gc/ngap/ie"
 	utils "github.com/free5gc/util/metrics/utils"
 )
 
@@ -42,11 +42,11 @@ func GetNgapHandlerMetrics(namespace string) []prometheus.Collector {
 	return collectors
 }
 
-func IncrMetricsRcvMsg(msgType string, metricStatusSuccess *bool, syntaxCause *ngapType.Cause) {
+func IncrMetricsRcvMsg(msgType string, metricStatusSuccess *bool, syntaxCause *ngapie.Cause) {
 	if IsNgapMetricsEnabled() {
 		msgCause := ""
 
-		if syntaxCause != nil && syntaxCause.Present != 0 {
+		if syntaxCause != nil && syntaxCause.Choice != nil {
 			msgCause = GetCauseErrorStr(syntaxCause)
 		}
 
@@ -58,7 +58,7 @@ func IncrMetricsRcvMsg(msgType string, metricStatusSuccess *bool, syntaxCause *n
 	}
 }
 
-func IncrMetricsSentMsg(msgType string, metricStatusSuccess *bool, syntaxCause ngapType.Cause, otherCause *string) {
+func IncrMetricsSentMsg(msgType string, metricStatusSuccess *bool, syntaxCause ngapie.Cause, otherCause *string) {
 	if IsNgapMetricsEnabled() {
 		msgCause := ""
 		causeErrStr := GetCauseErrorStr(&syntaxCause)

--- a/metrics/ngap/types.go
+++ b/metrics/ngap/types.go
@@ -106,6 +106,11 @@ const (
 	TARGET_RAN_NIL_ERR                          = "targetRan is nil"
 	UE_CTX_NIL                                  = "Ue context is nil"
 	UNKNOWN_NGAP_TYPE_CAUSE_ERR                 = "unknown ngapType.Cause"
+	// UNKNOWN_CAUSE_ERR is reported for a cause value outside of the maps in
+	// error_message.go, so that an unexpected value cannot inflate the
+	// cardinality of the cause label.
+	UNKNOWN_CAUSE_ERR             = "unknown cause"
+	CHOICE_EXTENSIONS_UNKNOWN_ERR = "ChoiceExtensions : Unknown error"
 )
 
 var ngapMetricsEnabled bool


### PR DESCRIPTION
Bump `github.com/free5gc/nas` and `github.com/free5gc/ngap` to the `feat/release` branch heads and migrate the two metrics subpackages off the removed `nasMessage` / `nasType` and `ngapType` packages.

The standalone `aper` module dependency is dropped: the new ngap module vendors it as `github.com/free5gc/ngap/aper`.

## API migration

- **metrics/nas** — `IncrMetricsRcvNasMsg` takes a `message.Message` instead of the old `*nas.Message` wrapper. Message names come from `MsgType()`, causes from `*ie.Cause5GMM`. The old 29-case switch did double duty (name **and** cause); only the cause half needs a type switch now, and it is provably complete: exactly 7 non-test files in the new `message` package declare a `Cause5GMM` field, and all 7 have a case.
- **metrics/ngap** — `GetCauseErrorStr` takes the Choice-based `*ie.Cause` union instead of `ngapType.Cause`.

## Metric labels are kept byte-identical

The obvious way to write both packages after the migration is to delegate to the `String()` methods of the new modules. This PR deliberately does not, because the label values are a public contract that dashboards and alerting rules are written against:

| | upstream `String()` | this PR |
|---|---|---|
| `name` (NAS) | `AuthReq`, `RegReq`, `SvcRej` | `AuthenticationRequest`, `RegistrationRequest`, `ServiceReject` |
| `cause` (NGAP) | `Radio Network Layer: Unspecified` | `RadioNetwork : Unspecified` |

Maps rather than switches so the mapping is a value the tests can walk; keying them on the upstream constants means an upstream rename breaks the build here instead of quietly changing a label.

## Behavior fixes

- A typed-nil `message.Message` — the shape produced by a deferred metrics call whose message was never decoded — is now counted under its message name instead of panicking on the `Cause5GMM` field access.
- `getMessageStrFromGmmMessage` no longer overwrites its `Unknown gmm message` default with an empty string for a message type it does not know.
- The old `ie.cause = *msg.DLNASTransport.Cause5GMM` dereference is gone; all cause IEs are pointers in the new API.
